### PR TITLE
Add emailing facility to an external address along with an attachment…

### DIFF
--- a/core/forms.py
+++ b/core/forms.py
@@ -1,9 +1,6 @@
-from django.forms import ModelForm
-from core.models import Report
+from django.forms import Form
 
 
-class ReportForm(ModelForm):
+class ReportForm(Form):
     class Meta:
-        model = Report
-        # fields = ('title', 'content', 'picture', 'url', 'hate_crime', 'police_brutality', 'civil_rights_violation',)
-        fields = ('hate_crime', 'police_brutality', 'civil_rights_violation', 'title', 'content', )
+        fields = ('send_to', 'subject', 'message', 'screenshot')

--- a/core/models.py
+++ b/core/models.py
@@ -9,19 +9,14 @@ class User(AbstractUser):
 class Report(models.Model):
 
     title = models.CharField(max_length=250)
-
-    # author = models.ForeignKey(
-    #     to=User, on_delete=models.CASCADE, related_name="reports"
-    # )
     content = models.TextField()
-    # user_content_edit = models.TextField()
     picture = models.ImageField(
         upload_to='images/', blank=True)
     videofile = models.FileField(
         upload_to='videos/', null=True, verbose_name="")
     url = models.URLField(max_length=255, null=True)
-
-
+    # send_to = models.EmailField(max_length=255)
+    # screenshot = models.BinaryField(max_length=None, editable=True, null=True)
     created_at = models.DateTimeField(auto_now_add=True)
 
     hate_crime = models.BooleanField(default=False)

--- a/core/templates/core/base.html
+++ b/core/templates/core/base.html
@@ -26,7 +26,7 @@
 				<a href="{% url 'home' %}" class="topbar">Home </a>
 			    <a href="{% url 'about' %}" >About us</a>      		
 			    <a href="{% url 'faq' %}" class="topbar">FAQs</a>
-			    <a href="{% url 'questions' %}" >Questionnaire</a>
+			
 				<a href="{% url 'report' %}" class="topbar">Report</a>	
 				<a href="{% url 'rights' %}" >Know Your Rights</a>
 				<a href="{% url 'reps' %}" class="topbar">Know Your Reps</a>	
@@ -38,7 +38,6 @@
 
 
 
-<a class="btn btn-default" href="{% url 'test_mail' %}">Send mail</a>
 		
 			{% block content %}
 <body>

--- a/core/templates/create_report.html
+++ b/core/templates/create_report.html
@@ -17,6 +17,7 @@
 <form role='form' action='' method='post'>
         {% csrf_token %}
         {{ form.as_p }}
+        
         <input type='submit' value="Submit" />
 </form>
 {% endblock content %}

--- a/core/views.py
+++ b/core/views.py
@@ -1,65 +1,79 @@
 from django.shortcuts import render, redirect
 from django.core import serializers
-from core.models import User, Report, Tweet
+from core.models import User, Report, Email
 from django.core.mail import send_mail
 import smtplib
 import json
 from django.db.models import Count
 from django.contrib import messages
 from core.forms import ReportForm
+from django.core.mail import EmailMessage
 
 
-def test_mail(request):
-    send_mail('hi', 'testing if this works', 'getJusticereport@gmail.com', [
-        'sowmya.aji@gmail.com', 'rebecca@momentum.com'], fail_silently=False)
-    return render(request, 'core/base.html')
+# def test_mail(request):
+#     send_mail('hi', 'testing if this works', 'getJusticereport@gmail.com', [
+#         'sowmya.aji@gmail.com', 'rebecca@momentum.com'], fail_silently=False)
+#     return render(request, 'core/base.html')
 
 
 def index(request):
     return render(request, 'core/index.html')
 
-def report_detail(request, id):
-    report = Report.objects.get(id=id)
-    return render(request, 'report_detail.html', {
-        'report': report,
-    })
+
+# with open("media/images/screen.png", "rb") as image_file:
+#     encoded_string = base64.b64encode(image_file.read())
+
+# form_data = {'subject': 'hi', 'message': 'one more test', 'send_to': [
+#     'sowmya.aji@gmail.com', 'rebecca@momentumlearn.com'], 'screenshot': encoded_string}
+
 
 def create_report(request):
     form_class = ReportForm
     if request.method == "POST":
         form = form_class(request.POST)
         if form.is_valid():
-            report = form.save(commit=False)
-            report.save()
-            return redirect('report_detail', id=report.id)
-        
-    else:
-        form = form_class()
-
-    return render(request, 'create_report.html', {
-            'form': form,
-        })
-
-def edit_report(request, id):
-    report = Report.objects.get(id=id)
-    form_class = ReportForm
-
-    if request.method == 'POST':
-        form = form_class(data=request.POST, instance=report)
-        if form.is_valid():
-            form.save()
+            subject = form.cleaned_data['subject']
+            message = form.cleaned_data['message']
+            send_to = form.cleaned_data['send_to']
+            screenshot = form.cleaned_data['screenshot']
+            msg = EmailMessage(
+                subject, message, 'getJusticereport@gmail.com', [send_to])
+            msg.content_subtype = "html"
+            msg.attach('screen.png', screenshot, 'image/png')
+            msg.send()
             message = f"Your report was sent!"
             messages.add_message(request, messages.SUCCESS, message)
             return render(request, 'core/index.html')
+    # report = form.save(commit=False)
+    # report.save()
     else:
-        form = form_class(instance=report)
+        form = form_class()
         message = f"For some reason your report didn't save. Please try again or contact us for assistance."
         messages.add_message(request, messages.ERROR, message)
-        return render(request, 'edit_report.html', {
-            'report': report,
+        return render(request, 'create_report.html', {
             'form': form,
-            })
+        })
 
+
+# def edit_report(request):
+#     report = Report.objects.all()
+#     form_class = ReportForm
+
+#     if request.method == 'POST':
+#         form = form_class(data=request.POST, instance=report)
+#         if form.is_valid():
+#             form.save()
+#             message = f"Your report was sent!"
+#             messages.add_message(request, messages.SUCCESS, message)
+#             return render(request, 'core/index.html')
+#     else:
+#         form = form_class(instance=report)
+#         message = f"For some reason your report didn't save. Please try again or contact us for assistance."
+#         messages.add_message(request, messages.ERROR, message)
+#         return render(request, '  create_report.html', {
+#             'report': report,
+#             'form': form,
+#         })
 
 
 def questions(request):
@@ -80,6 +94,7 @@ def faq(request):
 
 def terms(request):
     return render(request, 'core/terms.html')
+
 
 def reps(request):
     return render(request, 'reps.html')

--- a/maatjustice/settings.py
+++ b/maatjustice/settings.py
@@ -186,9 +186,15 @@ REST_FRAMEWORK = {
 # Activate django_heroku
 django_heroku.settings(locals())
 
-EMAIL_HOST = 'smtp.sendgrid.net'
-EMAIL_HOST_USER = 'apikey'
-EMAIL_HOST_PASSWORD = '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'
+# EMAIL_HOST = 'smtp.sendgrid.net'
+# EMAIL_HOST_USER = 'apikey'
+# EMAIL_HOST_PASSWORD = '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'
+# EMAIL_PORT = 587
+# EMAIL_USE_TLS = True
+EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
+
+EMAIL_HOST = 'smtp.mailgun.org'
+EMAIL_HOST_USER = 'postmaster@sandbox4edfacbb1d754aa69d01d3943ff88476.mailgun.org'
+EMAIL_HOST_PASSWORD = '694ed47ce132f8699c89b567d4029fc6-060550c6-678be20a'
 EMAIL_PORT = 587
 EMAIL_USE_TLS = True
-EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'

--- a/maatjustice/urls.py
+++ b/maatjustice/urls.py
@@ -24,13 +24,12 @@ urlpatterns = [
     # path('', include('pwa.urls')),
     path('', views.index, name='home'),
     path('create-report/', views.create_report, name='report'),
-    # path('report-sent/', views.report_sent, name='sent'),
-    path('report-draft/<int:id>', views.report_detail, name='report_detail'),
-    path('edit-report/<int:id>', views.edit_report, name='edit_report'),
-    path('accounts/', include('allauth.urls')),
+
+
+
     path('about/', views.about, name='about'),
-    path('question/', views.questions, name="questions"),
-    path('email/', views.test_mail, name="test_mail"),
+
+
     path('faq/', views.faq, name='faq'),
     path('your-rights/', views.rights, name="rights"),
     path('your-reps/', views.reps, name='reps'),


### PR DESCRIPTION
…, via Mailgun (in place of SendGrid)

@dacs2010 @tiana-horn  have added Mailgun (SendGrid is also there in the settings commented out, as the account is still suspending). Mailgun needs verified recipients (which means whoever receives the email has to accept that they will take mails from us) which kind of limits the people we can send the reports to. But for testing, we should be fine. We can request the Sheriff and Mayor (when we meet them) to accept our request and we can send it. Anyway the code is done :) so have pushed it. Please see and merge, thanks. 